### PR TITLE
[Add] useSelectedLayoutOut을 이용한 Navbar 추가

### DIFF
--- a/src/app/(afterLogin)/memoList/page.tsx
+++ b/src/app/(afterLogin)/memoList/page.tsx
@@ -1,38 +1,37 @@
-"use client"
+'use client';
 
-import FirebaseConfig from "@/app/_component/firebaseConfig/firebaseConfig";
-import { ref, onValue, get } from "firebase/database";
-import { useEffect, useState } from "react";
-import styled from "styled-components";
+import FirebaseConfig from '@/app/_component/firebaseConfig/firebaseConfig';
+import { ref, get } from 'firebase/database';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 
-export default  function MemoList(){
-    const database = FirebaseConfig();
-    const memoListRef = ref(database, "Customer/" + "test" + "/contents");
+export default function MemoList() {
+  const database = FirebaseConfig();
+  const memoListRef = ref(database, 'Customer/' + 'test' + '/contents');
 
-    const [isData, setIsData] = useState("");
-    get(memoListRef).then((snapshot)=>{
-        if(snapshot.exists()){
-            const data = snapshot.val();
-            setIsData(data)
-        }
-        // console.log("메모리스트", data)
+  const [isData, setIsData] = useState('');
 
-    })
+  useEffect(() => {
+    get(memoListRef).then(snapshot => {
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        setIsData(data);
+      }
+    });
+  }, []);
 
-
-    return(
-        <Container>
-                <div>내용:::::     {isData}</div>
-
-        </Container>
-    )
+  return (
+    <Container>
+      <div>내용 {isData}</div>
+    </Container>
+  );
 }
 
 const Container = styled.div`
-    width: 100dvw;
-    height: 100dvh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: bisque;
-`
+  width: 100dvw;
+  height: 100dvh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: bisque;
+`;

--- a/src/app/(afterLogin)/memoList/page.tsx
+++ b/src/app/(afterLogin)/memoList/page.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import FirebaseConfig from "@/app/_component/firebaseConfig/firebaseConfig";
+import { ref, onValue, get } from "firebase/database";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+export default  function MemoList(){
+    const database = FirebaseConfig();
+    const memoListRef = ref(database, "Customer/" + "test" + "/contents");
+
+    const [isData, setIsData] = useState("");
+    get(memoListRef).then((snapshot)=>{
+        if(snapshot.exists()){
+            const data = snapshot.val();
+            setIsData(data)
+        }
+        // console.log("메모리스트", data)
+
+    })
+
+
+    return(
+        <Container>
+                <div>내용:::::     {isData}</div>
+
+        </Container>
+    )
+}
+
+const Container = styled.div`
+    width: 100dvw;
+    height: 100dvh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: bisque;
+`

--- a/src/app/_component/NavBar.tsx
+++ b/src/app/_component/NavBar.tsx
@@ -1,24 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import NavSelectedSegment from './NavSelectedSegment';
 import Link from 'next/link';
-import { useSelectedLayoutSegment } from 'next/navigation';
 import Image from 'next/image';
 import profile from '../../../public/images/icon_user.png';
 import { signOut, useSession } from 'next-auth/react';
-import { useRouter } from 'next/router';
 
 export default function NavBar() {
-  const segment = useSelectedLayoutSegment();
-  // console.log(segment)
   const session = useSession();
-  const userEmail = session.data?.user?.name;
+  const userEmail = useMemo(() => {
+    return session.data?.user?.name;
+  }, [session.data?.user]);
 
-  const isClicked = () => {
-    const router = useRouter;
-  };
   return (
     <Container>
       <Wrapper>
@@ -58,7 +53,6 @@ const Wrapper = styled.div`
   height: inherit;
   width: inherit;
   background-color: #f9f9f9;
-  /* gap: 200px; */
 `;
 
 const LogoArea = styled.div`

--- a/src/app/_component/NavBar.tsx
+++ b/src/app/_component/NavBar.tsx
@@ -5,16 +5,43 @@ import styled from "styled-components"
 import NavSelectedSegment from "./NavSelectedSegment"
 import Link from "next/link"
 import { useSelectedLayoutSegment } from "next/navigation"
+import Image from "next/image"
+import profile from "../../../public/images/icon_user.png"
+import { signOut, useSession } from "next-auth/react"
+import { useRouter } from "next/router"
+
 
 export default function NavBar(){
     const segment = useSelectedLayoutSegment();
-    console.log(segment)
+    // console.log(segment)
+    const session = useSession();
+    const userEmail = session.data?.user?.name
+
+
+    const isClicked = () => {
+        const router = useRouter
+    }
     return(
         <Container>
             <Wrapper>
-                <ul>
-                    <NavSelectedSegment />
-                </ul>
+                <LogoArea>
+                    <HomeBtn href={"/"}  >
+                        write now
+                    </HomeBtn>
+                </LogoArea>
+                <MenuArea>
+                    <ul>
+                        <NavSelectedSegment />
+                    </ul>
+                </MenuArea>
+                <ProfileArea>
+                    { session.data?.user && 
+                    <>
+                        <Image  src={profile} alt="iconProfile" width={30} height={30} />
+                        <div>{userEmail}</div>
+                    </>}
+                    <LogoutBtn onClick={()=> signOut()}>로그아웃</LogoutBtn>
+                </ProfileArea>
             </Wrapper>
         </Container>
     )
@@ -34,6 +61,43 @@ const Wrapper = styled.div`
     height: inherit;
     width: inherit;
     background-color: #f9f9f9;
+    /* gap: 200px; */
+`
+
+const LogoArea = styled.div`
+    margin-top: 50px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`
+
+const HomeBtn = styled(Link)`
+    all: unset;
+    text-decoration-line: none;  
+    cursor: pointer;
+    font-size: 40px;
+    font-size: 700;
+`
+
+const MenuArea = styled.div`
+    flex:1;
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+`
+
+const ProfileArea = styled.div`
+    margin-bottom: 50px;
+    flex:1;
+    display: flex;
+    flex-direction: row;
+    align-items: end;
+    justify-content: center;
     gap: 10px;
 `
 
+const LogoutBtn = styled.button`
+    all: unset;
+    cursor: pointer;
+    font-size: 18px;
+`

--- a/src/app/_component/NavSelectedSegment.tsx
+++ b/src/app/_component/NavSelectedSegment.tsx
@@ -11,25 +11,25 @@ export default function NavSelectedSegment(){
     const segment = useSelectedLayoutSegment();
     return(
         <>
-                   { segment === 'home' ? 
+                   { segment === 'memoList' ? 
                     <LiTagSelected>
-                            <StyledLink href={"/home"}>
+                            <StyledLink href={"/memoList"}>
                                 <Menu>
                                     <IconWrapper>
                                         <Image src={memoFill} width={30} height={30} alt="memoIcon"/>
                                     </IconWrapper>
-                                    <TextWrapper>홈</TextWrapper>
+                                    <TextWrapper>메모</TextWrapper>
                                 </Menu>
                             </StyledLink>
                     </LiTagSelected>
                     :
                     <LiTag>
-                    <StyledLink href={"/home"}>
+                    <StyledLink href={"/memoList"}>
                         <Menu>
                             <IconWrapper>
                                 <Image src={memoEmpty} width={30} height={30} alt="memoIcon"/>
                             </IconWrapper>
-                            <TextWrapper>홈</TextWrapper>
+                            <TextWrapper>메모</TextWrapper>
                         </Menu>
                     </StyledLink>
                 </LiTag>
@@ -66,7 +66,7 @@ export default function NavSelectedSegment(){
 const LiTag = styled.li`
     list-style-type: none;
     :hover {
-        background-color: #f2efe6;
+        background-color: #f4f5de;
         border-top-right-radius: 30px;
         border-bottom-right-radius: 30px;
     }


### PR DESCRIPTION

**추가사항**
1. 네브바 이동 경로
- 최상단 write now : `"/"` 으로 이동
- 메모 : `"/memoList"`로 이동
- 보관 : `"/bookmark"`로 이동 
- 로그아웃: next-auth의 `signOut`을 이용해 로그아웃

<br/>

2.  `useSelectedLayOut` 을 이용해 네브바의 메뉴(메모,보관)가 눌러졌을 때의 UI가 달라지도록 적용

<br/>
<br/>

**Navbar 영상**

https://github.com/ny-plus-ny/write_now/assets/102043741/36560285-8d38-48f7-bed1-58d85b75d8bc
